### PR TITLE
[FIX] pms_pwa: Current year was max year in the calendar widget, nos …

### DIFF
--- a/pms_pwa/static/src/js/o_pms_pwa_calendar.js
+++ b/pms_pwa/static/src/js/o_pms_pwa_calendar.js
@@ -93,7 +93,7 @@ odoo.define("pms_pwa.calendar", function (require) {
                     showDropdowns: true,
                     autoUpdateInput: false,
                     minYear: 1901,
-                    maxYear: parseInt(moment().format("YYYY"), 10),
+                    maxYear: parseInt(moment().format("YYYY"), 10) + 5,
                 },
                 function (start) {
                     //console.log(start);
@@ -146,7 +146,7 @@ odoo.define("pms_pwa.calendar", function (require) {
                     showDropdowns: true,
                     autoUpdateInput: false,
                     minYear: 1901,
-                    maxYear: parseInt(moment().format("YYYY"), 10),
+                    maxYear: parseInt(moment().format("YYYY"), 10) + 5,
                 },
                 function (start) {
                     //console.log(start);


### PR DESCRIPTION
…is current year plus five.