### PR TITLE
[IMP] pms_pwa: specify avinit dependency

### DIFF
--- a/pms_pwa/__manifest__.py
+++ b/pms_pwa/__manifest__.py
@@ -15,7 +15,9 @@
     ],
     "website": "https://github.com/OCA/pms",
     "depends": ["base", "website", "pms", "bus"],
-    "extra_dependencies": ["avinit"],
+    "external_dependencies": {
+        "python": ["avinit"],
+    },
     "data": [
         "templates/_includes/head.xml",
         "templates/modal.xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# generated from manifests external_dependencies
+avinit


### PR DESCRIPTION
- Save it in the manifest.
- Add a `requirements.txt` file.

@moduon MT-295 @DarioLodeiros 